### PR TITLE
Keep password secret

### DIFF
--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -9,7 +9,15 @@
                               "ASDF"
                               "REPL"
                               "DB_APP_NAME"
+                              "SECRET-VALUES:SECRET-VALUE"
                               "HTTP"))
+  (0.4.0 2026-01-09
+         "
+Changes
+=======
+
+Now password, read from DB_PASSWORD is wrapped into SECRET-VALUES:SECRET-VALUE to prevent it's leak to the logs during printing backtrace.
+")
   (0.3.0 2025-02-08
          "
 Backward Incompatible Changes

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -9,6 +9,7 @@
                               "ASDF"
                               "REPL"
                               "DB_APP_NAME"
+                              "DB_PASSWORD"
                               "SECRET-VALUES:SECRET-VALUE"
                               "HTTP"))
   (0.4.0 2026-01-09

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -17,7 +17,7 @@
 Changes
 =======
 
-Now password, read from DB_PASSWORD is wrapped into SECRET-VALUES:SECRET-VALUE to prevent it's leak to the logs during printing backtrace.
+Now password, read from `DB_PASSWORD` is wrapped into SECRET-VALUES:SECRET-VALUE to prevent it's leak to the logs during printing backtrace.
 ")
   (0.3.0 2025-02-08
          "

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,11 +1,11 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "https://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2024-10-12"))
+  :version "2026-01-01"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "https://dist.ultralisp.org/" :%version :latest)
-  :version "20250205154500"))
+  :version "20260109190000"))
 ("slynk" .
  (:class qlot/source/github:source-github
   :initargs (:repos "svetlyak40wt/sly" :ref nil :branch "patches" :tag nil)

--- a/src/settings.lisp
+++ b/src/settings.lisp
@@ -3,6 +3,8 @@
   (:import-from #:bordeaux-threads-2
                 #:thread-name
                 #:current-thread)
+  (:import-from #:secret-values
+                #:conceal-value)
   (:export #:get-db-user
            #:get-db-pass
            #:get-db-name
@@ -31,7 +33,8 @@
       "root"))
 
 (defun get-db-pass ()
-  (uiop:getenv "DB_PASSWORD"))
+  (conceal-value
+   (uiop:getenv "DB_PASSWORD")))
 
 
 (defun get-default-application-name ()


### PR DESCRIPTION
Now password, read from DB_PASSWORD is wrapped into SECRET-VALUES:SECRET-VALUE to prevent it's leak to the logs during printing backtrace.